### PR TITLE
fix: Update GitHub Container Registry Token Reference in CI workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.GHCR_TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check, Build, Test, Publish
         uses: devcontainers/ci@v0.3

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,7 +23,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.GHCR_TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check, Build, Test, Publish
         uses: devcontainers/ci@v0.3


### PR DESCRIPTION
The previous token name does not exist as secret. [Here](https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/6389#note_4429726) it is suggested to use `GITHUB_TOKEN` instead of `GHCR_TOKEN`.