### PR TITLE
Upload correct container image

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,6 +38,7 @@ jobs:
           # publish latest from main branch; tags are handled in release workflow
           imageTag: latest
           refFilterForPush: 'refs/heads/main'
+          subFolder: src/s-core-devcontainer
           runCmd: |
             # Check
             pre-commit run --show-diff-on-failure --color=always --all-files || exit -1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,6 +31,7 @@ jobs:
           imageName: ghcr.io/eclipse-score/devcontainer
           cacheFrom: ghcr.io/eclipse-score/devcontainer
           imageTag: ${{ github.ref_name }}
+          subFolder: src/s-core-devcontainer
           runCmd: |
             # Check
             pre-commit run --show-diff-on-failure --color=always --all-files || exit -1


### PR DESCRIPTION
The devcontainer/ci action uploaded the devcontainer used to develop the S-CORE devcontainer. But it should have uploaded the S-CORE devcontainer instead.

According to https://github.com/devcontainers/ci/blob/main/docs/github-action.md#inputs `subFolder` should specify the correct path to the container.