### PR TITLE
fix: Handle containerception

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,15 +30,10 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Check, Build, Test, Publish
+      # Use .devcontainer from THIS repo for building and testing
+      - name: Check, Build, Test
         uses: devcontainers/ci@v0.3
         with:
-          cacheFrom: ghcr.io/eclipse-score/devcontainer
-          imageName: ghcr.io/eclipse-score/devcontainer
-          # publish latest from main branch; tags are handled in release workflow
-          imageTag: latest
-          refFilterForPush: 'refs/heads/main'
-          subFolder: src/s-core-devcontainer
           runCmd: |
             # Check
             pre-commit run --show-diff-on-failure --color=always --all-files || exit -1
@@ -48,3 +43,14 @@ jobs:
 
             # Test
             ./scripts/test.sh
+
+      # Upload devcontainer from src/s-core-devcontainer
+      - name: Publish
+        uses: devcontainers/ci@v0.3
+        with:
+          cacheFrom: ghcr.io/eclipse-score/devcontainer
+          imageName: ghcr.io/eclipse-score/devcontainer
+          # publish latest from main branch; tags are handled in release workflow
+          imageTag: latest
+          refFilterForPush: 'refs/heads/main'
+          subFolder: src/s-core-devcontainer

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,13 +25,10 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Check, Build, Test, Publish
+      # Use .devcontainer from THIS repo for building and testing
+      - name: Check, Build, Test
         uses: devcontainers/ci@v0.3
         with:
-          imageName: ghcr.io/eclipse-score/devcontainer
-          cacheFrom: ghcr.io/eclipse-score/devcontainer
-          imageTag: ${{ github.ref_name }}
-          subFolder: src/s-core-devcontainer
           runCmd: |
             # Check
             pre-commit run --show-diff-on-failure --color=always --all-files || exit -1
@@ -41,3 +38,12 @@ jobs:
 
             # Test
             ./scripts/test.sh
+
+      # Upload devcontainer from src/s-core-devcontainer
+      - name: Publish
+        uses: devcontainers/ci@v0.3
+        with:
+          imageName: ghcr.io/eclipse-score/devcontainer
+          cacheFrom: ghcr.io/eclipse-score/devcontainer
+          imageTag: ${{ github.ref_name }}
+          subFolder: src/s-core-devcontainer


### PR DESCRIPTION
This repo uses a devcontainer to build and test another devcontainer. The [devcontainer/ci](https://github.com/devcontainers/ci/tree/main) action was not really designed with this use case in mind. Maybe it works by splitting it into multiple steps.