### PR TITLE
Fix: Permissions of Bazel Cache Directory

### DIFF
--- a/src/s-core-devcontainer/.devcontainer/devcontainer.json
+++ b/src/s-core-devcontainer/.devcontainer/devcontainer.json
@@ -59,6 +59,7 @@
                 "bazelbuild.vscode-bazel",
                 "dbaeumer.vscode-eslint",
                 "EditorConfig.EditorConfig",
+                "ms-vscode.live-server", // for live preview of HTML files
                 "llvm-vs-code-extensions.vscode-clangd",
                 "jebbs.plantuml", //to preview PlantUML diagrams
                 "hediet.vscode-drawio", //for drawio integration

--- a/src/s-core-devcontainer/.devcontainer/s-core-local/post_create_command.sh
+++ b/src/s-core-devcontainer/.devcontainer/s-core-local/post_create_command.sh
@@ -4,6 +4,9 @@ set -euo pipefail
 # Configure Bazel to use the cache directory that is mounted from the host
 echo "startup --output_user_root=/var/cache/bazel" >> ~/.bazelrc
 
+# ensure that the Bazel cache directory has the correct permissions
+sudo chown -R "$(id -un):$(id -gn)" /var/cache/bazel
+
 # Configure clangd to remove the -fno-canonical-system-headers flag, which is
 # GCC-specific. If not done, there is an annoying error message on the first
 # line of every C++ file when being displayed in Visual Studio Code.


### PR DESCRIPTION
When running in CodeSpaces (and probably similar environments), the Bazel cache directory permissions are not correct and any Bazel operation would fail. This PR fixes this permission problem.

Also: add [Live Preview](https://marketplace.visualstudio.com/items?itemName=ms-vscode.live-server) extension from Microsoft, which is very practical when previewing rendered HTML pages from within VSCode.