### PR TITLE
Add qemu-system-aarch64 and sshpass to docker image

### DIFF
--- a/src/s-core-devcontainer/.devcontainer/s-core-local/install.sh
+++ b/src/s-core-devcontainer/.devcontainer/s-core-local/install.sh
@@ -90,6 +90,12 @@ gunzip -d /tmp/rust-analyzer.gz
 mv /tmp/rust-analyzer /usr/local/bin/rust-analyzer
 chmod +x /usr/local/bin/rust-analyzer
 
+# qemu-system-aarch64
+apt-get install -y qemu-system-aarch64
+
+# sshpass
+apt-get install -y sshpass
+
 # Cleanup
 apt-get autoremove -y
 apt-get clean

--- a/src/s-core-devcontainer/.devcontainer/s-core-local/tests/test_default.sh
+++ b/src/s-core-devcontainer/.devcontainer/s-core-local/tests/test_default.sh
@@ -15,3 +15,7 @@ check "validate rust-analyzer is working" bash -c "rust-analyzer --version"
 
 # Other build-related tools
 check "validate protoc is working" bash -c "protoc --version"
+
+# Qemu target-related tools
+check "validate qemu-system-aarch64 is working" bash -c "qemu-system-aarch64 --version"
+check "validate sshpass is working" bash -c "sshpass -V"


### PR DESCRIPTION
These tools are needed to run disk images and interact with them via e.g. bazel using ssh.