### PR TITLE
Install bazel version required by the repo

### DIFF
--- a/src/s-core-devcontainer/.devcontainer/s-core-local/devcontainer-feature.json
+++ b/src/s-core-devcontainer/.devcontainer/s-core-local/devcontainer-feature.json
@@ -31,10 +31,13 @@
         }
     },
     "onCreateCommand": "/devcontainer/features/s-core-local/on_create_command.sh",
-	"mounts": [ {
+    // The repos in S-CORE may use different Bazel versions. This ensures that the required version is installed
+    "postCreateCommand": "if [ -f .bazelversion ]; then sudo apt update && sudo apt install bazel-$(cat .bazelversion); fi",
+    "mounts": [
+        {
             "source": "${localEnv:HOME}/.cache/bazel", // default Bazel cache directory
             "target": "/var/cache/bazel",
             "type": "bind"
         }
-	]
+    ]
 }


### PR DESCRIPTION
S-CORE is sadly not a monorepo and each repo may use a different bazel version. Instead of preinstalling all of them the chosen bazel version is installed, when the container is created. This keeps the image smaller and can adapt better to changes in the repo.