### PR TITLE
Refactor Bazel cache configuration in on_create_command.sh

### DIFF
--- a/src/s-core-devcontainer/.devcontainer/s-core-local/on_create_command.sh
+++ b/src/s-core-devcontainer/.devcontainer/s-core-local/on_create_command.sh
@@ -1,10 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# If /var/cache/bazel exists, it was mounted from the host (see devcontainer-feature.json).
-# Hence, we configure Bazel to use this cache directory instead of the default cache (${HOME}/.cache/bazel).
-# This way, Bazel can re-use an existing cache on the host machine.
-# Note that in some scenarios (like codespaces), this is not the case and hence the cache stays in the container.
+# In some scenarios (like CodeSpaces), apparently not all (or even any?)
+# bind mounts to the host are done and /var/cache/bazel does not exist.
+# See devcontainer-feature.json, where this mount is defined.
+# Hence, if /var/cache/bazel exists, it was mounted from the host,
+# and we configure Bazel to use /var/cache/bazel as cache.
+# This way, Bazel re-uses a bind-mounted cache from the host machine, while
+# still using the default cache (${HOME}/.cache/bazel) if no such cache exists.
 if [ -d /var/cache/bazel ]; then
   echo "Configuring Bazel to use /var/cache/bazel as cache..."
   echo "startup --output_user_root=/var/cache/bazel" >> ~/.bazelrc

--- a/src/s-core-devcontainer/.devcontainer/s-core-local/on_create_command.sh
+++ b/src/s-core-devcontainer/.devcontainer/s-core-local/on_create_command.sh
@@ -1,26 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# ensure that the Bazel cache directory exists
-if [ ! -d /var/cache/bazel ]; then
-  echo "Creating /var/cache/bazel directory..."
-  # yes, mkdir -p is idempotent, but we want to see the log message
-  mkdir -p /var/cache/bazel
+# If /var/cache/bazel exists, it was mounted from the host (see devcontainer-feature.json).
+# Hence, we configure Bazel to use this cache directory instead of the default cache (${HOME}/.cache/bazel).
+# This way, Bazel can re-use an existing cache on the host machine.
+# Note that in some scenarios (like codespaces), this is not the case and hence the cache stays in the container.
+if [ -d /var/cache/bazel ]; then
+  echo "Configuring Bazel to use /var/cache/bazel as cache..."
+  echo "startup --output_user_root=/var/cache/bazel" >> ~/.bazelrc
 fi
-
-# If /var/cache/bazel is not a mountpoint, we assume it is a container-local cache.
-# This is the case in codespaces, for example.
-# Here, we must ensure that the directory has the correct permissions
-# so that Bazel can write to it.
-if ! mountpoint -q /var/cache/bazel; then
-    echo "/var/cache/bazel is not mounted. Using container-local cache and setting permissions."
-    chown -R "$(id -un):$(id -gn)" /var/cache/bazel
-fi
-
-# Configure Bazel to use the cache directory
-# This way, Bazel can re-use an existing cache on the host machine, if mounted.
-# Note that in some scenarios (like codespaces), it is not and hence resides in the container.
-echo "startup --output_user_root=/var/cache/bazel" >> ~/.bazelrc
 
 # Configure clangd to remove the -fno-canonical-system-headers flag, which is
 # GCC-specific. If not done, there is an annoying error message on the first


### PR DESCRIPTION
This changes the logic of how a Bazel cache from a host is used:

- In case `/var/cache/bazel` exists, it is one mounted from the host into the container, and we should use it
- Otherwise, simply let Bazel do it's thing and use `${HOME}/.cache/bazel`. There is nothing to re-use anyway. This is the case for CodeSpaces, for example; hence this closes #18 