### PR TITLE
Replace bind-mount with volume as Bazel Cache

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,9 @@
     "image": "mcr.microsoft.com/devcontainers/javascript-node:0-18",
     "features": {
         "ghcr.io/devcontainers/features/git:1": {},
-        "ghcr.io/devcontainers/features/git-lfs:1": {},
+        "ghcr.io/devcontainers/features/git-lfs:1": {
+            "autoPull": "false" // do not automatically pull LFS files when creating the container
+        },
         "ghcr.io/devcontainers/features/docker-in-docker:2": {},
         "ghcr.io/devcontainers-extra/features/pre-commit:2": {
             "version": "4.2.0"

--- a/README.md
+++ b/README.md
@@ -24,14 +24,12 @@ It should contain the following:
 ````json
 {
     "name": "eclipse-s-core",
-    "image": "ghcr.io/eclipse-score/devcontainer:<version>",
-    "initializeCommand": "mkdir -p ${localEnv:HOME}/.cache/bazel"
+    "image": "ghcr.io/eclipse-score/devcontainer:<version>"
 }
 ````
 
 The `<version>` must be a [valid, published release](https://github.com/eclipse-score/devcontainer/tags).
 You can also use `latest` as `<version>` to automatically follow the `main` branch - but be aware that this can result in undesired updates.
-The `initializeCommand` is required to ensure the default Bazel cache directory exists on your host system.
 
 To start using the container, click the **Reopen in Container** button when prompted by Visual Studio Code:
 

--- a/src/s-core-devcontainer/.devcontainer/s-core-local/devcontainer-feature.json
+++ b/src/s-core-devcontainer/.devcontainer/s-core-local/devcontainer-feature.json
@@ -36,9 +36,9 @@
     "postCreateCommand": "if [ -f .bazelversion ] && [ \"$(cat .bazelversion)\" != \"$(dpkg --list | grep 'ii  bazel   ' | awk '{print $3}')\" ]; then sudo apt-get update && sudo apt-get install -y --allow-downgrades bazel=$(cat .bazelversion); fi",
     "mounts": [
         {
-            "source": "${localEnv:HOME}/.cache/bazel", // default Bazel cache directory
+            "source": "eclipse-s-core-bazel-cache",
             "target": "/var/cache/bazel",
-            "type": "bind"
+            "type": "volume"
         }
     ]
 }


### PR DESCRIPTION
Since bind-mounting the Bazel cache from the host causes various problems (problematic access rights; incompatibilities with CodeSpaces) without major benefits, we use now a regular named volume as persistent cache.

Closes #18 (now hopefully for real)