### PR TITLE
Use correct platform name for ARM64-based chips

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 set -euxo pipefail
 
-devcontainer build --platform linux/aarch64 --workspace-folder src/s-core-devcontainer --image-name ghcr.io/eclipse-score/devcontainer --cache-from ghcr.io/eclipse-score/devcontainer
+devcontainer build --platform linux/arm64 --workspace-folder src/s-core-devcontainer --image-name ghcr.io/eclipse-score/devcontainer --cache-from ghcr.io/eclipse-score/devcontainer
 devcontainer build --platform linux/amd64 --workspace-folder src/s-core-devcontainer --image-name ghcr.io/eclipse-score/devcontainer --cache-from ghcr.io/eclipse-score/devcontainer

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -15,5 +15,5 @@ for IMAGE in "${IMAGES[@]}"; do
     DEVCONTAINER_CALL+=" $IMAGE"
 done
 
-eval "$DEVCONTAINER_CALL --platform linux/aarch64"
+eval "$DEVCONTAINER_CALL --platform linux/arm64"
 eval "$DEVCONTAINER_CALL --platform linux/amd64"


### PR DESCRIPTION
At least on MacOS, the current name does not work. platform/arm64 is correct.