### PR TITLE
Add Catch2 test adapter extension

### DIFF
--- a/src/s-core-devcontainer/.devcontainer/devcontainer.json
+++ b/src/s-core-devcontainer/.devcontainer/devcontainer.json
@@ -81,6 +81,8 @@
                     "--experimental_enable_label_completions"
                 ],
                 "C_Cpp.intelliSenseEngine": "disabled",
+                // This only supports basic tests: https://github.com/matepek/vscode-catch2-test-adapter/issues/429
+                // More complex tests may need execution via bazel, which is not done yet.
                 "testMate.cpp.test.executables": "bazel-bin/**/*{test,Test,TEST}*",
                 "tasks": {
                     "version": "2.0.0",


### PR DESCRIPTION
The extension discovers GTest based C++ tests in Visual Studio Code, where they can be run or debugged.

The current settings only work in simple use-cases: https://github.com/matepek/vscode-catch2-test-adapter/issues/429
Tests are currently **NOT** run via bazel, nor is their current working directory changed.

Related to #38 