### PR TITLE
Auto discover Rust tests

### DIFF
--- a/src/s-core-devcontainer/.devcontainer/devcontainer.json
+++ b/src/s-core-devcontainer/.devcontainer/devcontainer.json
@@ -80,6 +80,7 @@
                     "--experimental_enable_label_completions"
                 ],
                 "C_Cpp.intelliSenseEngine": "disabled",
+                "rust-analyzer.testExplorer": true,
                 "tasks": {
                     "version": "2.0.0",
                     "tasks": [


### PR DESCRIPTION
rust-analyzer can tell Visual Studio Code which tests exist. But in combination with Bazel this is currently hardly useful. Tests can be executed, but not debugged, which mostly nullifies having the tests in Visual Studio Code.

Until we have figured out how to debug tests as well, I see no point in merging this and this pull request acts more like documentation.

Related to #38 