### PR TITLE
Add cargo and rustup bash completion

### DIFF
--- a/src/s-core-devcontainer/.devcontainer/s-core-local/install.sh
+++ b/src/s-core-devcontainer/.devcontainer/s-core-local/install.sh
@@ -105,6 +105,10 @@ apt-get install -y --no-install-recommends --fix-broken qemu-system-arm="${qemu_
 # sshpass
 apt-get install -y sshpass="${sshpass_version}*"
 
+# Bash completion for rust tooling
+rustup completions bash rustup >> /etc/bash_completion.d/rustup.bash
+rustup completions bash cargo >> /etc/bash_completion.d/cargo.bash
+
 # Cleanup
 # REMOVE CONTAINER BUILD DEPENDENCIES
 apt-get remove --purge -y apt-transport-https


### PR DESCRIPTION
These tools are installed already in the devcontainer and used by some incubator repositories. It does not harm to have bash completion for them as long as they are installed.