### PR TITLE
Change Tag Names to have v-Prefix

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,7 +3,7 @@ description: 'This workflow is checking that for releases, updates do not break 
 on:
   push:
     tags:
-      - '[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+'
 jobs:
   build:
     strategy:


### PR DESCRIPTION
Since all S-CORE modules use a v-prefix in front of their semvers, the devcontainer should do the same.