### PR TITLE
fix: store configured bazel version in container image

### DIFF
--- a/src/s-core-devcontainer/.devcontainer/s-core-local/install.sh
+++ b/src/s-core-devcontainer/.devcontainer/s-core-local/install.sh
@@ -64,8 +64,9 @@ rm /tmp/bazelisk.deb
 
 # Pre-install a fixed Bazel version, setup the bash command completion
 export USE_BAZEL_VERSION=${bazel_version}
-bazel help completion bash > /tmp/bazel-complete.bash
-ls -lah /tmp/bazel-complete.bash
+# bazelisk downloads Bazel into the home directory of the user running the command
+# lets assume there is only one user in the devcontainer
+su $(ls /home) -c "bazel help completion bash > /tmp/bazel-complete.bash"
 mkdir -p /etc/bash_completion.d
 mv /tmp/bazel-complete.bash /etc/bash_completion.d/bazel-complete.bash
 sh -c "echo 'INSTALLED_BAZEL_VERSION=${bazel_version}' >> /devcontainer/features/s-core-local/bazel_setup.sh"

--- a/src/s-core-devcontainer/.devcontainer/s-core-local/tests/test_default.sh
+++ b/src/s-core-devcontainer/.devcontainer/s-core-local/tests/test_default.sh
@@ -28,12 +28,11 @@ check "validate pytest is working" bash -c "pytest --version"
 check "validate pylint is working" bash -c "pylint --version"
 
 # Bazel-related tools
-check "validate bazelisk is working and has the correct version" bash -c "bazelisk version | grep '${bazelisk_version}'"
-
 ## This is the bazel version preinstalled in the devcontainer.
 ## A solid test would disable the network interface first to prevent a different version from being downloaded,
 ## but that requires CAP_NET_ADMIN, which is not yet added.
 export USE_BAZEL_VERSION=${bazel_version}
+check "validate bazelisk is working and has the correct version" bash -c "bazelisk version | grep '${bazelisk_version}'"
 check "validate bazel is working and has the correct version" bash -c "bazel version | grep '${bazel_version}'"
 unset USE_BAZEL_VERSION
 


### PR DESCRIPTION
install.sh is run as root and downloads bazel into roots home. Now
bazel is downloaded by the vscode user, so that the configured bazel version
is accessible without second download.