### PR TITLE
Bump OpenJDK version to 21.0.10

### DIFF
--- a/src/s-core-devcontainer/.devcontainer/s-core-local/versions.yaml
+++ b/src/s-core-devcontainer/.devcontainer/s-core-local/versions.yaml
@@ -27,7 +27,7 @@ gh:
   version: 2.45.0
 
 openjdk_21:
-  version: 21.0.9
+  version: 21.0.10
 
 valgrind:
   version: 3.22.0


### PR DESCRIPTION
This fixes a build break on main because the old version went away.