### PR TITLE
Fix CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,12 +28,10 @@ jobs:
         os: [arm64, amd64]
         include:
           - os: amd64
-            name: build/amd64
-            description: DevContainer (amd64)
+            name: DevContainer (amd64)
             runner: ubuntu-24.04
           - os: arm64
-            name: build/arm64
-            description: DevContainer (arm64)
+            name: DevContainer (arm64)
             runner: ubuntu-24.04-arm
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.runner }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,6 @@ on:
     branches:
       - main
   merge_group:
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -82,10 +81,8 @@ jobs:
               echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
               ./scripts/publish.sh --${{ matrix.os }} "main"
             fi
-
   overall-result:
     name: build/overall-result
-    description: Overall Result
     runs-on: ubuntu-24.04
     needs: [build/amd64, build/arm64]
     if: ${{ !cancelled() }}
@@ -96,7 +93,6 @@ jobs:
       - name: Failing verification
         if: ${{ contains(needs.*.result, 'failure') }}
         run: exit 1
-
   merge:
     name: Merge Labels (main only)
     needs: [build]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -84,7 +84,7 @@ jobs:
   overall-result:
     name: build/overall-result
     runs-on: ubuntu-24.04
-    needs: [build/amd64, build/arm64]
+    needs: [build]
     if: ${{ !cancelled() }}
     steps:
       - name: Successful verification


### PR DESCRIPTION
The description field is not part of the [workflow scheme](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobs) and causes the entire workflow file to be ignored.

The `needs` dependencies tried to account for all instances of a matrix job, but should have taken only the generic matrix job name. It will automatically depend on all instances of the matrix job.