### PR TITLE
fix: persistent apparmor linux-sandbox rule, write permission for pr check workflow

### DIFF
--- a/.github/workflows/pr-title-semantic.yaml
+++ b/.github/workflows/pr-title-semantic.yaml
@@ -20,7 +20,7 @@ on:
       - reopened
       - synchronize
 permissions:
-  pull-requests: read
+  pull-requests: write
 jobs:
   semantic-pr-title:
     name: Semantic PR Title

--- a/README.md
+++ b/README.md
@@ -113,7 +113,8 @@ Canonical [decided to restrict user namespaces for security reasons](https://dis
 To still be able to use `linux-sandbox` without disabling `apparmor` run the following commands on your host:
 
 ```bash
-sudo tee /etc/apparmor.d/bazel-linux-sandbox > /dev/null <<EOF
+# prefix with aaa for ordering with default Ubuntu user namespace rule, which would restrict linux-sandbox
+sudo tee /etc/apparmor.d/aaa-bazel-linux-sandbox > /dev/null <<EOF
 abi <abi/4.0>,
 include <tunables/global>
 
@@ -121,10 +122,10 @@ profile linux-sandbox /var/cache/bazel/install/*/linux-sandbox flags=(unconfined
   userns,
 
   # Site-specific additions and overrides. See local/README for details.
-  include if exists <local/bazel-linux-sandbox>
+  include if exists <local/aaa-bazel-linux-sandbox>
 }
 EOF
-sudo apparmor_parser -r /etc/apparmor.d/bazel-linux-sandbox
+sudo apparmor_parser -r /etc/apparmor.d/aaa-bazel-linux-sandbox
 ```
 
 When done


### PR DESCRIPTION
The linux-sandbox profile was not active after reboot. Most likely it is either because it was loaded before or after the profile, which disables Linux namespaces for most applications. With the aaa prefix it works when tested with `systemctl restart apparmor.service`.

The pr title workflow should write a comment, if the check fails. But the [workflow lacked the write permission](https://github.com/marocchino/sticky-pull-request-comment?tab=readme-ov-file#error-resource-not-accessible-by-integration). With that it should work.