### PR TITLE
feat: add lcov to devcontainer image

### DIFF
--- a/src/s-core-devcontainer/.devcontainer/s-core-local/install.sh
+++ b/src/s-core-devcontainer/.devcontainer/s-core-local/install.sh
@@ -96,6 +96,9 @@ apt-get install -y gdb="${gdb_version}*"
 
 apt-get install -y valgrind="1:${valgrind_version}*"
 
+# lcov - code coverage reporting for C/C++
+apt-get install -y lcov="${lcov_version}*"
+
 # CodeQL
 apt-get install -y zstd
 if [ "${ARCHITECTURE}" = "amd64" ]; then

--- a/src/s-core-devcontainer/.devcontainer/s-core-local/tests/test_default.sh
+++ b/src/s-core-devcontainer/.devcontainer/s-core-local/tests/test_default.sh
@@ -84,6 +84,9 @@ if [ "${ARCHITECTURE}" = "amd64" ] || { [ "${ARCHITECTURE}" = "arm64" ] && [ "${
     check "validate CODEQL_HOME is set correctly" bash -c "echo ${CODEQL_HOME} | grep \"/usr/local/codeql\""
 fi
 
+# lcov
+check "validate lcov is working and has the correct version" bash -c "lcov --version | grep '${lcov_version}'"
+
 # Qemu target-related tools
 check "validate qemu-system-aarch64 is working and has the correct version" bash -c "qemu-system-aarch64 --version | grep '${qemu_system_arm_version}'"
 check "validate sshpass is working and has the correct version" bash -c "sshpass -V | grep '${sshpass_version}'"

--- a/src/s-core-devcontainer/.devcontainer/s-core-local/versions.yaml
+++ b/src/s-core-devcontainer/.devcontainer/s-core-local/versions.yaml
@@ -47,3 +47,5 @@ codeql_coding_standards:
   version: 2.54.0
 valgrind:
   version: 3.22.0
+lcov:
+  version: 2.0


### PR DESCRIPTION
Install lcov as part of the devcontainer so that individual CI workflows no longer need to install it via apt-get at runtime. This decouples build tooling from workflow definitions, moving towards reproducible and hermetic build environments.