### PR TITLE
ci: Minimal permissions for overall-result job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -92,6 +92,7 @@ jobs:
     runs-on: ubuntu-24.04
     needs: [build]
     if: ${{ !cancelled() }}
+    permissions: {}
     steps:
       - name: Successful verification
         if: ${{ !(contains(needs.*.result, 'failure')) }}


### PR DESCRIPTION
Potential fix for [https://github.com/eclipse-score/devcontainer/security/code-scanning/1](https://github.com/eclipse-score/devcontainer/security/code-scanning/1)

Add an explicit `permissions` block to the `overall-result` job in `.github/workflows/ci.yaml` to restrict `GITHUB_TOKEN` access to least privilege.  
Best fix without changing behavior: set `permissions: {}` for `overall-result`, since it only evaluates `needs` results and exits with status codes; it does not require repository/package/ID-token scopes.

Change region: in `.github/workflows/ci.yaml`, inside `jobs.overall-result`, add the permissions block between `if:` and `steps:` (or anywhere valid under the job root keys). No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
