### PR TITLE
fix: Bump openjdk patch version

### DIFF
--- a/src/s-core-devcontainer/.devcontainer/s-core-local/versions.yaml
+++ b/src/s-core-devcontainer/.devcontainer/s-core-local/versions.yaml
@@ -33,7 +33,7 @@ pytest:
 gh:
   version: 2.45.0
 openjdk_21:
-  version: 21.0.10
+  version: 21.0.11
 codeql:
   # the coding_standards_version below dictates the codeql version
   version: 2.21.4


### PR DESCRIPTION
Ubuntu updated the patch level and we have to follow. Otherwise the container fails to build.