### PR TITLE
feat: Add ripgrep to the container image

### DIFF
--- a/src/s-core-devcontainer/.devcontainer/s-core-local/install.sh
+++ b/src/s-core-devcontainer/.devcontainer/s-core-local/install.sh
@@ -96,6 +96,8 @@ apt-get install -y gdb="${gdb_version}*"
 
 apt-get install -y valgrind="1:${valgrind_version}*"
 
+apt-get install -y ripgrep="${ripgrep_version}*"
+
 # lcov - code coverage reporting for C/C++
 apt-get install -y lcov="${lcov_version}*"
 

--- a/src/s-core-devcontainer/.devcontainer/s-core-local/tests/test_default.sh
+++ b/src/s-core-devcontainer/.devcontainer/s-core-local/tests/test_default.sh
@@ -79,6 +79,7 @@ check "validate uvx is working and has the correct version" bash -c "uvx --versi
 check "validate gdb is working and has the correct version" bash -c "gdb --version | grep '${gdb_version}'"
 check "validate gh is working and has the correct version" bash -c "gh --version | grep '${gh_version}'"
 check "validate valgrind is working and has the correct version" bash -c "valgrind --version | grep '${valgrind_version}'"
+check "validate ripgrep is working and has the correct version" bash -c "rg --version | grep '${ripgrep_version}'"
 if [ "${ARCHITECTURE}" = "amd64" ] || { [ "${ARCHITECTURE}" = "arm64" ] && [ "${KERNEL}" = "Darwin" ]; }; then
     check "validate codeql is working and has the correct version" bash -c "codeql --version | grep '${codeql_version}'"
     check "validate CODEQL_HOME is set correctly" bash -c "echo ${CODEQL_HOME} | grep \"/usr/local/codeql\""

--- a/src/s-core-devcontainer/.devcontainer/s-core-local/versions.yaml
+++ b/src/s-core-devcontainer/.devcontainer/s-core-local/versions.yaml
@@ -47,5 +47,7 @@ codeql_coding_standards:
   version: 2.54.0
 valgrind:
   version: 3.22.0
+ripgrep:
+  version: 14.1.0
 lcov:
   version: 2.0


### PR DESCRIPTION
ripgrep is used a lot by LLMs, which have to fallback to grep in the absense of ripgrep.