### PR TITLE
feat: install pre-commit from shared catalog

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,10 +1,5 @@
 {
   "features": {
-    "ghcr.io/devcontainers-extra/features/pre-commit:2": {
-      "version": "2.0.18",
-      "resolved": "ghcr.io/devcontainers-extra/features/pre-commit@sha256:6e0bb2ce80caca1d94f44dab5d0653d88a1c00984e590adb7c6bce012d0ade6e",
-      "integrity": "sha256:6e0bb2ce80caca1d94f44dab5d0653d88a1c00984e590adb7c6bce012d0ade6e"
-    },
     "ghcr.io/devcontainers/features/docker-in-docker:4": {
       "version": "4.0.0",
       "resolved": "ghcr.io/devcontainers/features/docker-in-docker@sha256:4fa87399214366e320d489991769c4f3f461e1ffe461f54eea78a41b34945bb5",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,9 +3,6 @@
     "features": {
         "ghcr.io/devcontainers/features/docker-in-docker:4": {
             "moby": "false" // does not work with Debian Trixie based images
-        },
-        "ghcr.io/devcontainers-extra/features/pre-commit:2": {
-            "version": "4.5.1"
         }
     },
     "postCreateCommand": "${containerWorkspaceFolder}/.devcontainer/post_create_command.sh",

--- a/.devcontainer/post_create_command.sh
+++ b/.devcontainer/post_create_command.sh
@@ -18,8 +18,17 @@ npm install -g @devcontainers/cli
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 REPOSITORY_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd -P)"
 
-sudo "${REPOSITORY_ROOT}/tools/internal/devcontainer/install.py" install actionlint bazelisk buildifier ruff shellcheck yamlfmt
+# Install uv and uvx from the native lockfile first. The pinned uv release then
+# resolves every Python distribution declared in the shared catalog.
+sudo "${REPOSITORY_ROOT}/tools/internal/devcontainer/install.py" install actionlint bazelisk buildifier ruff shellcheck uv uvx yamlfmt
 
+# Install the catalogued Python distribution system-wide. The explicit
+# directories avoid root-specific uv defaults and make pre-commit available to
+# the non-root development user.
+sudo "${REPOSITORY_ROOT}/tools/internal/devcontainer/install.py" install-python pre-commit \
+    --bin-dir /usr/local/bin --tool-dir /usr/local/share/uv/tools
+
+# Hooks can only be registered after the catalogued executable is on PATH.
 pre-commit install
 
 scripts/create_builder.sh

--- a/README.md
+++ b/README.md
@@ -388,7 +388,7 @@ There should rarely be a need to modify this.
 This repo uses [`reuse`](https://codeberg.org/fsfe/reuse-tool) to check for and validate licenses and copyrights.
 Checks are performend via pre-commit hooks.
 
-If you want to run it standalone run `pipx run reuse lint` in a terminal.
+If you want to run it standalone, run `tools/run-tool uvx reuse lint` in a terminal.
 To fix found issues run `scripts/run_reuse_annotate.sh`.
 
 ### Modify, Build, Test, Use

--- a/scripts/run_reuse_annotate.sh
+++ b/scripts/run_reuse_annotate.sh
@@ -28,7 +28,8 @@ files_to_annotate=$(comm -23 <(git ls-files | sort) <(echo "${deleted_files}" | 
 
 # shellcheck disable=SC2086
 # Expansion of ${files_to_annotate} is intentional to pass the list of files as separate arguments to the reuse annotate command.
-pipx run reuse annotate --template apache-2.0 --merge-copyrights --recursive --skip-unrecognised \
+# The shared runner supplies the catalogued uvx binary in containers and Bazel.
+tools/run-tool uvx reuse annotate --template apache-2.0 --merge-copyrights --recursive --skip-unrecognised \
  --copyright="Contributors to the Eclipse Foundation" --license=Apache-2.0 ${files_to_annotate}
 
 popd > /dev/null

--- a/src/s-core-devcontainer/.devcontainer/devcontainer-lock.json
+++ b/src/s-core-devcontainer/.devcontainer/devcontainer-lock.json
@@ -5,11 +5,6 @@
       "resolved": "ghcr.io/devcontainers-community/features/llvm@sha256:4f464ab97a59439286a55490b55ba9851616f6f76ac3025e134127ac08ad79e2",
       "integrity": "sha256:4f464ab97a59439286a55490b55ba9851616f6f76ac3025e134127ac08ad79e2"
     },
-    "ghcr.io/devcontainers-extra/features/pre-commit:2": {
-      "version": "2.0.18",
-      "resolved": "ghcr.io/devcontainers-extra/features/pre-commit@sha256:6e0bb2ce80caca1d94f44dab5d0653d88a1c00984e590adb7c6bce012d0ade6e",
-      "integrity": "sha256:6e0bb2ce80caca1d94f44dab5d0653d88a1c00984e590adb7c6bce012d0ade6e"
-    },
     "ghcr.io/devcontainers/features/common-utils": {
       "version": "2.5.4",
       "resolved": "ghcr.io/devcontainers/features/common-utils@sha256:00fd45550f578d9d515044d9e2226e908dbc3d7aa6fcb9dee4d8bdb60be114cf",

--- a/src/s-core-devcontainer/.devcontainer/s-core-local/devcontainer-feature.json
+++ b/src/s-core-devcontainer/.devcontainer/s-core-local/devcontainer-feature.json
@@ -2,12 +2,7 @@
     "name": "Eclipse S-CORE-specific Local Tools",
     "id": "s-core-local",
     "version": "1.0.0",
-    "description": "Tools which are not available as already existing development container feature",
-    "dependsOn": {
-        "ghcr.io/devcontainers-extra/features/pre-commit:2": {
-            "version": "4.5.1"
-        }
-    },
+    "description": "S-CORE-specific local development tools",
     "onCreateCommand": "/devcontainer/features/s-core-local/on_create_command.sh",
     "postCreateCommand": {
         "Fix ownership of mounted config volumes": "bash /devcontainer/features/s-core-local/fix_config_volume_ownership.sh",

--- a/src/s-core-devcontainer/.devcontainer/s-core-local/install.sh
+++ b/src/s-core-devcontainer/.devcontainer/s-core-local/install.sh
@@ -36,11 +36,6 @@ DEBIAN_FRONTEND=noninteractive
 ARCHITECTURE=$(dpkg --print-architecture)
 KERNEL=$(uname -s)
 
-# always add PIPX_BIN_DIR to path
-PIPX_BIN_DIR_EXPORT="$(grep "export PIPX_BIN_DIR" /etc/bash.bashrc)"
-eval "${PIPX_BIN_DIR_EXPORT}"
-echo -e "PATH=\"${PIPX_BIN_DIR}:\$PATH\"\nexport PATH" >> /etc/profile.d/pipx_bin_dir.sh
-
 apt-get update
 
 # Unminimize the image to include standard packages like man pages

--- a/src/s-core-devcontainer/.devcontainer/s-core-local/install.sh
+++ b/src/s-core-devcontainer/.devcontainer/s-core-local/install.sh
@@ -57,8 +57,15 @@ apt-get install -y "python${python_version}" python3-pip python3-venv
 # devcontainer feature "python" (cf. https://github.com/devcontainers/features/tree/main/src/python )
 apt-get install -y flake8 python3-autopep8 black python3-yapf mypy pydocstyle pycodestyle bandit pipenv virtualenv pylint
 
-# Lockfile-managed local developer tools
+# uv must be installed from the native lockfile before it can install the
+# Python distributions declared in the shared Python tool catalog below.
 /usr/local/share/score-tools/internal/devcontainer/install.py install shellcheck ruff actionlint yamlfmt uv uvx apm opencode
+
+# Keep Python CLIs in system directories so every DevContainer user sees the
+# same entrypoint and isolated environment. Bazel reads the same package pin
+# from this catalog but executes it on demand with uvx.
+/usr/local/share/score-tools/internal/devcontainer/install.py install-python pre-commit \
+    --bin-dir /usr/local/bin --tool-dir /usr/local/share/uv/tools
 
 # GraphViz
 # The Ubuntu Noble package of GraphViz

--- a/src/s-core-devcontainer/.devcontainer/s-core-local/tests/test_default.sh
+++ b/src/s-core-devcontainer/.devcontainer/s-core-local/tests/test_default.sh
@@ -30,8 +30,13 @@ uvx_lockfile_version="$(/usr/local/share/score-tools/internal/devcontainer/insta
 apm_lockfile_version="$(/usr/local/share/score-tools/internal/devcontainer/install.py version apm)"
 opencode_lockfile_version="$(/usr/local/share/score-tools/internal/devcontainer/install.py version opencode)"
 
-# pre-commit, it is available via $PATH in login shells, but not in non-login shells
-check "validate pre-commit is working and has the correct version" bash -c "pre-commit --version | grep '4.5.1'"
+# The shared catalog is the assertion source, so installation metadata and the
+# executable exposed on PATH are checked against the same release.
+pre_commit_catalog_version="$(/usr/local/share/score-tools/internal/devcontainer/install.py version pre-commit)"
+
+# Verify the system-wide uv installation exposes the catalogued release to the
+# non-root user running feature tests.
+check "validate pre-commit is working and has the correct version" bash -c "pre-commit --version | grep '${pre_commit_catalog_version}'"
 
 # Common tooling
 check "validate shellcheck is working and has the correct version" bash -c "shellcheck --version | grep '${shellcheck_lockfile_version}'"


### PR DESCRIPTION
## Summary
- install `pre-commit` 4.5.1 from the shared Python tool catalog with pinned `uv`
- remove the separate DevContainer feature and its generated lock entries
- route REUSE helper commands through the catalogued `uvx` runner
- verify the installed command against the catalogued version

## Rationale
The DevContainer PATH and Bazel target now consume one package pin while retaining delivery mechanisms suited to their environments. The REUSE workflow uses uvx directly and no longer relies on environment setup from another feature.

## Scope
This is the DevContainer integration layer of stack #145 and depends on PR #143. It contains the container wiring and the directly coupled migration of existing pipx-based REUSE commands.

## Validation
- full pre-commit suite
- isolated `uv tool install` using the catalogued package
- complete local `scripts/test.sh` DevContainer build and feature test